### PR TITLE
Make Regex less restrictive on Blowfish, MD5 and Sha Crypters

### DIFF
--- a/CryptSharp/BlowfishCrypter.cs
+++ b/CryptSharp/BlowfishCrypter.cs
@@ -130,7 +130,7 @@ namespace CryptSharp.Core
 
         private static string Regex
         {
-            get { return @"\A(?<prefix>\$2[axy]\$)(?<rounds>[0-9]{2})\$(?<salt>[A-Za-z0-9./]{22})(?<crypt>[A-Za-z0-9./]{"
+            get { return @"\A(?<prefix>\$2[axy]\$)(?<rounds>[0-9]{2})\$(?<salt>[^\$]{22})(?<crypt>[A-Za-z0-9./]{"
                 + ((BlowfishCipher.BCryptLength * 8 + 5) / 6).ToString() + @"})?\z"; }
         }
     }

--- a/CryptSharp/MD5Crypter.cs
+++ b/CryptSharp/MD5Crypter.cs
@@ -191,7 +191,7 @@ namespace CryptSharp.Core
 
         private static string Regex
         {
-            get { return @"\A(?<prefix>\$(apr)?1\$)(?<salt>[A-Za-z0-9./]{1,99})(\$(?<crypt>[A-Za-z0-9./]{22}))?\z"; }
+            get { return @"\A(?<prefix>\$(apr)?1\$)(?<salt>[^\$]{1,99})(\$(?<crypt>[A-Za-z0-9./]{22}))?\z"; }
         }
     }
 }

--- a/CryptSharp/ShaCrypter.cs
+++ b/CryptSharp/ShaCrypter.cs
@@ -201,7 +201,7 @@ namespace CryptSharp.Core
 
             string regex = @"\A"
                 + Regex.Escape(cryptPrefix)
-                + @"(rounds=(?<rounds>[0-9]{1,9})\$)?(?<salt>[A-Za-z0-9./]{1,99})(\$(?<crypt>[A-Za-z0-9./]{"
+                + @"(rounds=(?<rounds>[0-9]{1,9})\$)?(?<salt>[^\$]{1,99})(\$(?<crypt>[A-Za-z0-9./]{"
                 + keyCharacters.ToString()
                 + @"}))?\z";
             return new Regex(regex, RegexOptions.CultureInvariant);


### PR DESCRIPTION
Yes, this library is very spec-compliant in regards to the crypt(3) hash format.
Unfortunately, this causes issues occasionally.

Specifically, the salt was supposedly invalid, despite being seen as valid by OpenSSL, Dovecot, Postfix, and some other software.

Upon closer inspection, I realized this library strictly adheres to crypt(3) standards on parsing due to the regex used for parsing Blowfish, MD5 and SHA crypt-hashes.

This PR makes the regex less restrictive, to allow parsing crypthashes with crypt(3)-incompliant salts.